### PR TITLE
Remove break-all and font-size from guides tips

### DIFF
--- a/css.styl
+++ b/css.styl
@@ -8,7 +8,6 @@
 
 .guides
   float: left
-  font-size: 21px
   position: relative
 
   code
@@ -23,7 +22,6 @@
     left: 0
     position: absolute
     top: 100px
-    word-break: break-all
 
   .hidden
     display: none


### PR DESCRIPTION
Sidebar text that appears when hovering over each part of package.json has poor readability. These changes improve it; see comparison:

* Before: http://i.imgur.com/l3RLjJW.png break-all word wrap makes text too difficult/confusing to follow, large font size attempts to squeeze too much text in too little a space
* After: http://i.imgur.com/r2meRpF.png eaiser to read; lines are not broken mid-word and smaller font size allows for more comfortable reading