### PR TITLE
Fixed semver ^0.7.0 shorthand

### DIFF
--- a/view.html
+++ b/view.html
@@ -371,7 +371,7 @@
       <p>
         Require the <a href="https://github.com/flatiron/vows">vows</a>module as
         development dependency. The ^ in the version is a shorthand for
-        <code>&gt;=0.7.0 &lt; 1.0.0</code>.
+        <code>&gt;=0.7.0 &lt; 0.8.0</code>.
       </p>
     </article>
 


### PR DESCRIPTION
Shorthand for >=0.7.0 <0.8.0, not <1.0.0.  See: https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004
